### PR TITLE
fixed zsh shell

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func parse(value string) object {
 }
 
 func command(c string) (string, error) {
-	out, err := exec.Command("zsh", "-c", c).Output()
+	out, err := exec.Command("sh", "-c", c).Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
zsh is not on every system installed, so changing it to sh should work for every system.
Windows not included 