### PR TITLE
wrong arg check and didn't make all dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+git-file

--- a/main.go
+++ b/main.go
@@ -21,9 +21,10 @@ const TMP_FOLDER_LOCATION = "tmp_git_file/"
 func main() {
 	args := os.Args
 
-	if len(args) < 1 {
+	if len(args) < 2 {
 		fmt.Println("Not enough arguments")
-	} else if len(args) < 2 {
+        os.Exit(0)
+	} else if len(args) < 3 {
 		args = append(args, ".")
 	}
 
@@ -40,7 +41,7 @@ func download(url, location string) error {
 	object := parse(url)
 	path := fmt.Sprintf("%s%s/", TMP_FOLDER_LOCATION, object.RepoName)
 
-	err := os.Mkdir(path, os.ModePerm)
+	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
when checking how many arguments were given it didn't work. because the length of arguments is never lower than one.

also when downloading the file to the temp folder you wanted to make multiple folders but that doesn't work if temp folder doesn't exist yet.

Also thinking on changing the temp folder to /temp